### PR TITLE
fix: remove buffer() for fetchLocalAudio

### DIFF
--- a/lib/crunker.js
+++ b/lib/crunker.js
@@ -59,9 +59,7 @@ class NodeCrunker {
   async fetchLocalAudio(...filepaths) {
     try {
       const files = filepaths.map(async filepath => {
-        const buffer = await readFile(filepath).then(response =>
-          response.buffer()
-        );
+        const buffer = await readFile(filepath);
         return await new Promise((resolve, reject) =>
           this._context.decodeAudioData(
             buffer,


### PR DESCRIPTION
This fixes the: "TypeError: response.buffer is not a function" error when using `fetchLocalAudio`. The file already is a buffer when using fs.readFile, so this was failing:

```
TypeError: response.buffer is not a function
    at readFile.then.response (/Users/camsloan/Documents/development/personal/audio-stitcher/node_modules/node-crunker/lib/crunker.js:64:20)
```